### PR TITLE
feat(ui): replace mock data with proper empty states

### DIFF
--- a/src/renderer/components/bento/BentoDashboard.tsx
+++ b/src/renderer/components/bento/BentoDashboard.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
-import type { CalendarEvent, CalendarListResult } from '@shared/types';
+import React, { useEffect, useState, useCallback } from 'react';
+import type { CalendarEvent, CalendarListResult, Meeting } from '@shared/types';
+import { useAppStore } from '@renderer/stores/appStore';
 import CompactMeetingBar from './CompactMeetingBar';
 import UpcomingMeetingsList from './UpcomingMeetingsList';
 import PreviousMeetingsList from './PreviousMeetingsList';
@@ -10,58 +11,55 @@ interface BentoDashboardProps {
   onSelectTab?: (tab: 'notes' | 'prep' | 'interact') => void;
 }
 
-export default function BentoDashboard({ isRecording, onStartNotes, onSelectTab }: BentoDashboardProps) {
+type CompletedMeeting = Meeting & { endedAt: Date };
+
+export default function BentoDashboard({ isRecording, onStartNotes, onSelectTab }: BentoDashboardProps): JSX.Element {
+  const { setView, setSelectedMeeting } = useAppStore();
   const [upcomingEvent, setUpcomingEvent] = useState<CalendarEvent | null>(null);
   const [calendarEvents, setCalendarEvents] = useState<CalendarEvent[]>([]);
+  const [previousMeetings, setPreviousMeetings] = useState<CompletedMeeting[]>([]);
 
-  // Placeholder meetings shown when no calendar connected
-  const placeholderMeetings: CalendarEvent[] = [
-    {
-      id: 'placeholder-1',
-      title: 'Connect your calendar',
-      start: new Date(Date.now() + 7200000),
-      end: new Date(Date.now() + 10800000),
-      provider: 'google',
-      location: 'Settings',
-    },
-  ];
-
-  // Mock previous meetings (placeholder)
-  const mockPreviousMeetings = [
-    {
-      id: 'prev-1',
-      title: 'Sprint Planning',
-      start: new Date(Date.now() - 86400000),
-      end: new Date(Date.now() - 82800000),
-      hasTranscript: true,
-    },
-    {
-      id: 'prev-2',
-      title: 'Design Review',
-      start: new Date(Date.now() - 172800000),
-      end: new Date(Date.now() - 169200000),
-      hasTranscript: true,
-    },
-    {
-      id: 'prev-3',
-      title: 'Client Check-in',
-      start: new Date(Date.now() - 259200000),
-      end: new Date(Date.now() - 255600000),
-      hasTranscript: false,
-    },
-  ];
-
-  useEffect(() => {
-    window.kakarot.calendar.listToday().then((result: CalendarListResult) => {
-      setCalendarEvents(result.events);
-      if (result.events.length > 0) {
-        setUpcomingEvent(result.events[0]);
-      }
-    });
+  const loadPreviousMeetings = useCallback(async () => {
+    try {
+      const meetings = await window.kakarot.meetings.list();
+      const completed = meetings
+        .filter((m): m is CompletedMeeting => m.endedAt !== null)
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .slice(0, 5);
+      setPreviousMeetings(completed);
+    } catch (err) {
+      console.error('Failed to load previous meetings:', err);
+    }
   }, []);
 
-  const handleViewNotes = (_meetingId: string) => {
-    // TODO: Navigate to meeting notes view
+  useEffect(() => {
+    window.kakarot.calendar.listToday()
+      .then((result: CalendarListResult) => {
+        setCalendarEvents(result.events);
+        if (result.events.length > 0) {
+          setUpcomingEvent(result.events[0]);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load calendar events:', err);
+      });
+    loadPreviousMeetings();
+  }, [loadPreviousMeetings]);
+
+  const handleViewNotes = async (meetingId: string) => {
+    try {
+      const meeting = await window.kakarot.meetings.get(meetingId);
+      if (meeting) {
+        setSelectedMeeting(meeting);
+        setView('history');
+      }
+    } catch (err) {
+      console.error('Failed to load meeting:', err);
+    }
+  };
+
+  const handleNavigateSettings = () => {
+    setView('settings');
   };
 
   return (
@@ -78,8 +76,20 @@ export default function BentoDashboard({ isRecording, onStartNotes, onSelectTab 
 
       {/* Two-column layout: Upcoming | Previous */}
       <div className="flex-1 grid grid-cols-2 gap-2.5 min-h-0">
-        <UpcomingMeetingsList meetings={calendarEvents.length > 0 ? calendarEvents : placeholderMeetings} />
-        <PreviousMeetingsList meetings={mockPreviousMeetings} onViewNotes={handleViewNotes} />
+        <UpcomingMeetingsList
+          meetings={calendarEvents}
+          onNavigateSettings={handleNavigateSettings}
+        />
+        <PreviousMeetingsList
+          meetings={previousMeetings.map((m) => ({
+            id: m.id,
+            title: m.title,
+            start: new Date(m.createdAt),
+            end: new Date(m.endedAt),
+            hasTranscript: m.transcript.length > 0,
+          }))}
+          onViewNotes={handleViewNotes}
+        />
       </div>
     </div>
   );

--- a/src/renderer/components/bento/ContextPanel.tsx
+++ b/src/renderer/components/bento/ContextPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { LucideIcon } from 'lucide-react';
 import { Clipboard, FileText, CheckSquare } from 'lucide-react';
 
 interface ContextPanelProps {
@@ -7,34 +8,40 @@ interface ContextPanelProps {
   actionItems?: { text: string; completed: boolean }[];
 }
 
+interface SectionHeaderProps {
+  icon: LucideIcon;
+  title: string;
+  iconColor: string;
+}
+
+function SectionHeader({ icon: Icon, title, iconColor }: SectionHeaderProps): JSX.Element {
+  return (
+    <div className="flex items-center gap-2 mb-3 px-2">
+      <Icon className={`w-4 h-4 ${iconColor}`} />
+      <h4 className="text-sm font-semibold text-slate-900 dark:text-white">{title}</h4>
+    </div>
+  );
+}
+
+interface SectionEmptyStateProps {
+  message: string;
+  bgClass: string;
+  borderClass: string;
+}
+
+function SectionEmptyState({ message, bgClass, borderClass }: SectionEmptyStateProps): JSX.Element {
+  return (
+    <div className={`px-3 py-4 rounded-lg ${bgClass} border ${borderClass} text-center`}>
+      <p className="text-xs text-slate-500 dark:text-slate-500 italic">{message}</p>
+    </div>
+  );
+}
+
 export default function ContextPanel({
   prepItems = [],
   recentNotes = [],
   actionItems = [],
-}: ContextPanelProps) {
-  // Default placeholder data
-  const defaultPrep = [
-    'Review previous meeting notes',
-    'Check action items from last sync',
-    'Prepare questions for discussion',
-  ];
-
-  const defaultNotes = [
-    'Discussed Q1 roadmap priorities',
-    'Agreed on sprint timeline',
-    'Follow-up needed on deployment',
-  ];
-
-  const defaultActions = [
-    { text: 'Update project timeline', completed: false },
-    { text: 'Schedule follow-up meeting', completed: true },
-    { text: 'Review design mockups', completed: false },
-  ];
-
-  const displayPrep = prepItems.length > 0 ? prepItems : defaultPrep;
-  const displayNotes = recentNotes.length > 0 ? recentNotes : defaultNotes;
-  const displayActions = actionItems.length > 0 ? actionItems : defaultActions;
-
+}: ContextPanelProps): JSX.Element {
   return (
     <div className="h-full rounded-2xl border border-white/30 dark:border-white/10 bg-white/70 dark:bg-graphite/80 backdrop-blur-md shadow-soft-card p-4 flex flex-col">
       <h3 className="text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 mb-4 px-2">
@@ -44,69 +51,84 @@ export default function ContextPanel({
       <div className="flex-1 overflow-y-auto space-y-5 pr-2 scrollbar-thin scrollbar-thumb-slate-300 dark:scrollbar-thumb-slate-600 scrollbar-track-transparent">
         {/* Prep Items */}
         <div>
-          <div className="flex items-center gap-2 mb-3 px-2">
-            <Clipboard className="w-4 h-4 text-[#7C3AED]" />
-            <h4 className="text-sm font-semibold text-slate-900 dark:text-white">Prep Items</h4>
-          </div>
+          <SectionHeader icon={Clipboard} title="Prep Items" iconColor="text-[#7C3AED]" />
           <div className="space-y-2">
-            {displayPrep.map((item, idx) => (
-              <div
-                key={idx}
-                className="px-3 py-2 rounded-lg bg-slate-100/50 dark:bg-slate-700/30 border border-slate-200/50 dark:border-slate-600/50"
-              >
-                <p className="text-sm text-slate-700 dark:text-slate-300">{item}</p>
-              </div>
-            ))}
+            {prepItems.length === 0 ? (
+              <SectionEmptyState
+                message="No prep items yet"
+                bgClass="bg-slate-100/30 dark:bg-slate-700/20"
+                borderClass="border-slate-200/30 dark:border-slate-600/30"
+              />
+            ) : (
+              prepItems.map((item, idx) => (
+                <div
+                  key={idx}
+                  className="px-3 py-2 rounded-lg bg-slate-100/50 dark:bg-slate-700/30 border border-slate-200/50 dark:border-slate-600/50"
+                >
+                  <p className="text-sm text-slate-700 dark:text-slate-300">{item}</p>
+                </div>
+              ))
+            )}
           </div>
         </div>
 
         {/* Recent Notes */}
         <div>
-          <div className="flex items-center gap-2 mb-3 px-2">
-            <FileText className="w-4 h-4 text-emerald-mist" />
-            <h4 className="text-sm font-semibold text-slate-900 dark:text-white">Recent Notes</h4>
-          </div>
+          <SectionHeader icon={FileText} title="Recent Notes" iconColor="text-emerald-mist" />
           <div className="space-y-2">
-            {displayNotes.map((note, idx) => (
-              <div
-                key={idx}
-                className="px-3 py-2 rounded-lg bg-emerald-mist/5 dark:bg-emerald-mist/10 border border-emerald-mist/20"
-              >
-                <p className="text-sm text-slate-700 dark:text-slate-300">{note}</p>
-              </div>
-            ))}
+            {recentNotes.length === 0 ? (
+              <SectionEmptyState
+                message="No recent notes"
+                bgClass="bg-emerald-mist/5 dark:bg-emerald-mist/10"
+                borderClass="border-emerald-mist/10"
+              />
+            ) : (
+              recentNotes.map((note, idx) => (
+                <div
+                  key={idx}
+                  className="px-3 py-2 rounded-lg bg-emerald-mist/5 dark:bg-emerald-mist/10 border border-emerald-mist/20"
+                >
+                  <p className="text-sm text-slate-700 dark:text-slate-300">{note}</p>
+                </div>
+              ))
+            )}
           </div>
         </div>
 
         {/* Action Items */}
         <div>
-          <div className="flex items-center gap-2 mb-3 px-2">
-            <CheckSquare className="w-4 h-4 text-amber-500" />
-            <h4 className="text-sm font-semibold text-slate-900 dark:text-white">Action Items</h4>
-          </div>
+          <SectionHeader icon={CheckSquare} title="Action Items" iconColor="text-amber-500" />
           <div className="space-y-2">
-            {displayActions.map((action, idx) => (
-              <div
-                key={idx}
-                className="px-3 py-2 rounded-lg bg-amber-500/5 dark:bg-amber-500/10 border border-amber-500/20 flex items-start gap-2"
-              >
-                <input
-                  type="checkbox"
-                  checked={action.completed}
-                  readOnly
-                  className="mt-0.5 w-4 h-4 rounded border-slate-300 dark:border-slate-600 text-emerald-mist focus:ring-emerald-mist/50"
-                />
-                <p
-                  className={`text-sm flex-1 ${
-                    action.completed
-                      ? 'line-through text-slate-500 dark:text-slate-500'
-                      : 'text-slate-700 dark:text-slate-300'
-                  }`}
+            {actionItems.length === 0 ? (
+              <SectionEmptyState
+                message="No action items"
+                bgClass="bg-amber-500/5 dark:bg-amber-500/10"
+                borderClass="border-amber-500/10"
+              />
+            ) : (
+              actionItems.map((action, idx) => (
+                <div
+                  key={idx}
+                  className="px-3 py-2 rounded-lg bg-amber-500/5 dark:bg-amber-500/10 border border-amber-500/20 flex items-start gap-2"
                 >
-                  {action.text}
-                </p>
-              </div>
-            ))}
+                  <input
+                    type="checkbox"
+                    checked={action.completed}
+                    readOnly
+                    className="mt-0.5 w-4 h-4 rounded border-slate-300 dark:border-slate-600 text-emerald-mist focus:ring-emerald-mist/50"
+                  />
+                  <p
+                    className={`text-sm flex-1 ${
+                      action.completed
+                        ? 'line-through text-slate-500 dark:text-slate-500'
+                        : 'text-slate-700 dark:text-slate-300'
+                    }`}
+                  >
+                    {action.text}
+                  </p>
+                </div>
+              ))
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Remove all hardcoded placeholder/mock data from Bento dashboard components
- Replace with proper empty states showing real data or actionable calls-to-action
- Add "Connect Calendar" button that navigates to Settings when no calendar connected
- Fetch real previous meetings from database instead of mock data

## Changes

### BentoDashboard.tsx
- Remove `placeholderMeetings` and `mockPreviousMeetings` arrays
- Add `loadPreviousMeetings()` to fetch real data from database
- Add `CompletedMeeting` type guard for type-safe `endedAt` handling
- Add error handling for all async IPC calls
- Wire up navigation to Settings and History views

### UpcomingMeetingsList.tsx
- Add `onNavigateSettings` prop for Settings navigation
- Empty state shows "Connect Calendar" button instead of placeholder event
- Extract `MeetingSection` component to reduce duplication
- Fix React keys to use `meeting.id` instead of array index

### ContextPanel.tsx
- Remove default placeholder data for prep items, notes, and action items
- Show per-section empty states: "No prep items yet", "No recent notes", "No action items"
- Extract `SectionHeader` and `SectionEmptyState` local components

## Test plan

- [ ] With no calendar connected: Verify "Connect Calendar" button appears and navigates to Settings
- [ ] With no previous meetings: Verify "No previous meetings" empty state appears
- [ ] With meetings in database: Verify real meetings appear in Previous Meetings list
- [ ] Click "View Notes" on previous meeting: Verify navigation to History view with meeting selected
- [ ] Verify all 3 Context Panel sections show empty states when no data passed

Closes #41